### PR TITLE
WAL-3164: Remove "reason" as filter for transactions/find

### DIFF
--- a/Source/CurrencyCloud/Entity/Find/TransactionFindParameters.cs
+++ b/Source/CurrencyCloud/Entity/Find/TransactionFindParameters.cs
@@ -66,12 +66,6 @@ namespace CurrencyCloud.Entity
         public string Type { get; set; }
 
         ///<summary>
-        /// Description of transactions - free form text
-        ///</summary>
-        [Param]
-        public string Reason { get; set; }
-
-        ///<summary>
         /// ISO 8601 expected processing date
         ///</summary>
         [Param]


### PR DESCRIPTION
Using "reason" as a filter for `transactions/find` has been deprecated.